### PR TITLE
Remove Base-64 Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,5 @@
     "rollup-plugin-typescript2": "^0.30.0",
     "typescript": "^4.2.3"
   },
-  "dependencies": {
-    "@types/base-64": "^1.0.0",
-    "base-64": "^1.0.0"
-  },
   "packageManager": "yarn@1.22.19"
 }

--- a/src/CredentialsContainer/Tokens/BasicToken.ts
+++ b/src/CredentialsContainer/Tokens/BasicToken.ts
@@ -22,7 +22,7 @@ export class BasicToken implements IToken {
 
     toString() {
         const payload = `${this.username}:${this.password}`
-        const token = Buffer.from(payload).toString('base64')
+        const token = Boolean(globalThis.Buffer) ? Buffer.from(payload).toString('base64') : btoa(payload)
         return `${TokenType.Basic} ${token}`
     }
 }

--- a/src/CredentialsContainer/Tokens/BasicToken.ts
+++ b/src/CredentialsContainer/Tokens/BasicToken.ts
@@ -1,4 +1,3 @@
-import Base64 from 'base-64'
 import { TokenType } from "../Enums";
 import type { IToken, BasicTokenOptions, JSONTokenFormat } from "../Types";
 
@@ -23,7 +22,7 @@ export class BasicToken implements IToken {
 
     toString() {
         const payload = `${this.username}:${this.password}`
-        const token = Base64.encode(payload)
+        const token = Buffer.from(payload).toString('base64')
         return `${TokenType.Basic} ${token}`
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,11 +924,6 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
-"@types/base-64@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/base-64/-/base-64-1.0.0.tgz#de9c6070ea457fbd65a1b5ebf13976b3ac0bdad0"
-  integrity sha512-AvCJx/HrfYHmOQRFdVvgKMplXfzTUizmh0tz9GFTpDePWgCY4uoKll84zKlaRoeiYiCr7c9ZnqSTzkl0BUVD6g==
-
 "@types/estree@*":
   version "0.0.50"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
@@ -1000,11 +995,6 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-base-64@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
-  integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This replaces the Base-64 package dependency with Node.JS' built-in Buffer. In case you are concerned about backward-compatibility, this is not a new feature in Node.JS, it has been supported for well over a decade. Node.JS' implementation is written in C, which is much more performant than the Base-64 package's implementation in JavaScript.